### PR TITLE
Create notification when moderator access of user is changed in a group

### DIFF
--- a/server/example.env
+++ b/server/example.env
@@ -15,3 +15,4 @@ FRONTEND_PORT=3000
 CLOUDINARY_CLOUD_NAME=<cloudinary-cloud-name>
 CLOUDINARY_API_KEY=<cloudinary-api-key>
 CLOUDINARY_API_SECRET=<cloudinary-api-secret>
+MANAGER_USERNAME=<username-of-manager-account>

--- a/server/models/groups/removeModerator.js
+++ b/server/models/groups/removeModerator.js
@@ -1,5 +1,5 @@
 const { pool } = require('../database')
-
+const notifications = require('../notifications')
 /**
  *
  * @param {*} param0
@@ -28,13 +28,13 @@ function removeModerator({ params, body, username }) {
           return reject('Given user do not have moderator access for the group')
         }
         pool.query(
-          `SELECT creator FROM \`groups\` WHERE id=?`,
+          `SELECT creator, group_name  FROM \`groups\` WHERE id=?`,
           [groupId],
           (error, results) => {
             if (error) {
               return reject(error)
             }
-            const { creator } = results[0]
+            const { creator, group_name: groupName } = results[0]
             if (creator === moderatorUsername) {
               return reject(
                 'Moderator access of the creator can not be changed'
@@ -52,7 +52,21 @@ function removeModerator({ params, body, username }) {
                     'Either the person is already not a moderator or no such person found in the group!'
                   )
                 }
-                return resolve('Successfully removed from moderator!!')
+                const port = process.env.FRONTEND_PORT || 3000
+                const host = process.env.FRONTEND_HOST || 'localhost'
+                const body = {
+                  heading: `Removed from moderator of ${groupName}`,
+                  description: `You are no longer a moderator of the group [${groupName}](http://${host}:${port}/groups/${groupId})`,
+                  public: false,
+                  target_usernames: [moderatorUsername],
+                }
+                const notification = {
+                  username: process.env.MANAGER_USERNAME,
+                  body,
+                }
+                notifications.createNotification(notification).then(() => {
+                  return resolve('Successfully removed from moderator!!')
+                })
               }
             )
           }


### PR DESCRIPTION
Fixes #59 

- I have skipped the notifications when users are added to a non-confidential group, as it seems to run a large number of queries. We can think for that later.