### PR TITLE
create: questions pages for viewing and managing them 

### DIFF
--- a/frontend/components/common/AdminNavbar/DesktopView.js
+++ b/frontend/components/common/AdminNavbar/DesktopView.js
@@ -18,7 +18,7 @@ function AdminNavbarDesktop (props) {
               <Nav.Link active={activeNav === 'contests'}>&nbsp;Contests&nbsp;</Nav.Link>
             </Link>
             <Link href="/manage/questions" passHref>
-              <Nav.Link>&nbsp;Questions&nbsp;</Nav.Link>
+              <Nav.Link active={activeNav === 'questions'}>&nbsp;Questions&nbsp;</Nav.Link>
             </Link>
             <Link href="/manage/articles" passHref>
               <Nav.Link>&nbsp;Articles&nbsp;</Nav.Link>

--- a/frontend/components/common/customBadge.js
+++ b/frontend/components/common/customBadge.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Badge } from 'react-bootstrap'
+
+const CustomBadge = ({ message, crossBtn, variant, onClose }) => {
+  return (
+        <Badge variant={variant}>
+            {message}
+            {crossBtn &&
+                <>
+                    &nbsp;
+                    <span className="fa fa-times hover-cursor-pointer" onClick={onClose} />
+                </>
+            }
+        </Badge>
+  )
+}
+
+CustomBadge.propTypes = {
+  message: PropTypes.string,
+  crossBtn: PropTypes.bool,
+  variant: PropTypes.string,
+  onClose: PropTypes.func
+}
+
+export default CustomBadge

--- a/frontend/components/manage/questions/index.js
+++ b/frontend/components/manage/questions/index.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ManageQuestionsListItem from './questionsListItem'
+import {
+  ListGroupItem, Row, Col
+} from 'react-bootstrap'
+
+const ManageQuestions = ({ questions, sortBy, handleSort }) => (
+    <>
+        <ListGroupItem
+          style={{
+            backgroundColor: '#f2f2f2'
+          }}
+        >
+          <Row>
+            <Col lg={1}>
+              <b className="hover-cursor-pointer" onClick={() => handleSort('id')}>
+                #
+                &nbsp;
+                {sortBy.id
+                  ? sortBy.id === 'ASC'
+                      ? <span className="fa fa-caret-down" />
+                      : <span className="fa fa-caret-up" />
+                  : <span className="fa fa-sort" />}
+              </b>
+            </Col>
+            <Col lg={6}>
+              <b className="hover-cursor-pointer" onClick={() => handleSort('name')}>
+                Name
+                &nbsp;
+                {sortBy.name
+                  ? sortBy.name === 'ASC'
+                      ? <span className="fa fa-caret-down" />
+                      : <span className="fa fa-caret-up" />
+                  : <span className="fa fa-sort" />}
+              </b>
+            </Col>
+            <Col lg={2} className='text-center'>
+              <b>Difficulty</b>
+            </Col>
+            <Col lg={3} className='text-center'>
+                <b>Creator</b>
+            </Col>
+          </Row>
+        </ListGroupItem>
+        {questions.map(({ ...question }, idx) => (
+          <ManageQuestionsListItem
+            key={question.id}
+            {...question}
+            backgroundColor={idx % 2 === 0 ? 'white' : '#f2f2f2'}
+          />
+        ))}
+        {!questions.length &&
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '25vh' }}>
+            Sorry! there are no questions to display
+          </div>
+        }
+    </>
+)
+
+ManageQuestions.propTypes = {
+  questions: PropTypes.array,
+  sortBy: PropTypes.object,
+  handleSort: PropTypes.func
+}
+
+export default ManageQuestions

--- a/frontend/components/manage/questions/questionsListItem.js
+++ b/frontend/components/manage/questions/questionsListItem.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { ListGroupItem, Row, Col, OverlayTrigger, Tooltip } from 'react-bootstrap'
+import Link from 'next/link'
+import PropTypes from 'prop-types'
+import CustomBadge from '../../common/customBadge'
+import styles from './questionsListItem.module.css'
+
+const ManageQuestionsListItem = ({ id, name, difficulty, backgroundColor, creator }) => {
+  let message = 'Easy'; let variant = 'success'
+  if (difficulty === 'medium') {
+    message = 'Medium'
+    variant = 'warning'
+  } else if (difficulty === 'hard') {
+    message = 'Hard'
+    variant = 'danger'
+  }
+
+  return (
+    <ListGroupItem className={styles.hoverBackground} style={{ backgroundColor }}>
+      <Row>
+        <Col lg={1}>
+          {id}
+        </Col>
+        <Col lg={6}>
+            <OverlayTrigger
+                placement="right"
+                overlay={<Tooltip>View and update question</Tooltip>}
+            >
+                {({ ref, ...triggerHandler }) => (
+                    <Link href={`/manage/questions/${id}`} passHref>
+                        <a ref={ref} {...triggerHandler}>{name}</a>
+                    </Link>
+                )}
+            </OverlayTrigger>
+        </Col>
+        <Col lg={2} className='text-center'>
+          <CustomBadge message={message} variant={variant} />
+        </Col>
+        <Col lg={3} className='text-center'>
+            {creator}
+        </Col>
+      </Row>
+    </ListGroupItem>
+  )
+}
+
+ManageQuestionsListItem.propTypes = {
+  name: PropTypes.string,
+  difficulty: PropTypes.string,
+  id: PropTypes.number,
+  backgroundColor: PropTypes.string,
+  creator: PropTypes.string
+}
+
+export default ManageQuestionsListItem

--- a/frontend/components/manage/questions/questionsListItem.module.css
+++ b/frontend/components/manage/questions/questionsListItem.module.css
@@ -1,0 +1,4 @@
+.hoverBackground:hover {
+    background-color: #d9d9d9 !important;
+    cursor: pointer;
+}

--- a/frontend/components/practice/index.js
+++ b/frontend/components/practice/index.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PracticeListItem from './practiceListItem'
+import {
+  ListGroupItem, Row, Col
+} from 'react-bootstrap'
+
+const Practice = ({ questions, sortBy, handleSort }) => (
+    <>
+        <ListGroupItem
+          style={{
+            backgroundColor: '#f2f2f2'
+          }}
+        >
+          <Row>
+            <Col lg={2}>
+              <b className="hover-cursor-pointer" onClick={() => handleSort('id')}>
+                #
+                &nbsp;
+                {sortBy.id
+                  ? sortBy.id === 'ASC'
+                      ? <span className="fa fa-caret-down" />
+                      : <span className="fa fa-caret-up" />
+                  : <span className="fa fa-sort" />}
+              </b>
+            </Col>
+            <Col lg={7}>
+              <b className="hover-cursor-pointer" onClick={() => handleSort('name')}>
+                Name
+                &nbsp;
+                {sortBy.name
+                  ? sortBy.name === 'ASC'
+                      ? <span className="fa fa-caret-down" />
+                      : <span className="fa fa-caret-up" />
+                  : <span className="fa fa-sort" />}
+              </b>
+            </Col>
+            <Col lg={3} className='text-center'>
+              <b>Difficulty</b>
+            </Col>
+          </Row>
+        </ListGroupItem>
+        {questions.map(({ id, name, difficulty }, idx) => (
+          <PracticeListItem
+            key={id}
+            id={id}
+            difficulty={difficulty}
+            name={name}
+            backgroundColor={idx % 2 === 0 ? 'white' : '#f2f2f2'}
+          />
+        ))}
+        {!questions.length &&
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '25vh' }}>
+            Sorry! there is no practice content available
+          </div>
+        }
+    </>
+)
+
+Practice.propTypes = {
+  questions: PropTypes.array,
+  sortBy: PropTypes.array,
+  handleSort: PropTypes.func
+}
+
+export default Practice

--- a/frontend/components/practice/practiceListItem.js
+++ b/frontend/components/practice/practiceListItem.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { ListGroupItem, Row, Col } from 'react-bootstrap'
+import Link from 'next/link'
+import PropTypes from 'prop-types'
+import CustomBadge from '../common/customBadge'
+import styles from './practiceListItem.module.css'
+
+const PracticeListItem = ({ id, name, difficulty, backgroundColor }) => {
+  let message = 'Easy'; let variant = 'success'
+  if (difficulty === 'medium') {
+    message = 'Medium'
+    variant = 'warning'
+  } else if (difficulty === 'hard') {
+    message = 'Hard'
+    variant = 'danger'
+  }
+
+  return (
+    <ListGroupItem className={styles.hoverBackground} style={{ backgroundColor }}>
+      <Row>
+        <Col lg={2}>
+          {id}
+        </Col>
+        <Col lg={7}>
+          <Link href={`/practice/${id}`} passHref>
+            {name}
+          </Link>
+        </Col>
+        <Col lg={3} className='text-center'>
+          <CustomBadge message={message} variant={variant} />
+        </Col>
+      </Row>
+    </ListGroupItem>
+  )
+}
+
+PracticeListItem.propTypes = {
+  name: PropTypes.string,
+  difficulty: PropTypes.string,
+  id: PropTypes.number,
+  backgroundColor: PropTypes.string
+}
+
+export default PracticeListItem

--- a/frontend/components/practice/practiceListItem.module.css
+++ b/frontend/components/practice/practiceListItem.module.css
@@ -1,0 +1,4 @@
+.hoverBackground:hover {
+    background-color: #d9d9d9 !important;
+    cursor: pointer;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4946,7 +4946,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5472,7 +5473,8 @@
     "is-docker": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "optional": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -8400,6 +8402,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8413,6 +8416,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -8421,6 +8425,7 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10103,7 +10108,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",
@@ -11431,7 +11437,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/frontend/pages/manage/questions/index.js
+++ b/frontend/pages/manage/questions/index.js
@@ -1,0 +1,325 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import Loading from '../../../components/common/Loading'
+import baseUrl from '../../../shared/baseUrl'
+import ManageQuestions from '../../../components/manage/questions/index'
+import AdminNavbar from '../../../components/common/AdminNavbar/index'
+import {
+  ListGroupItem, Row, Col, Form,
+  FormControl,
+  InputGroup,
+  DropdownButton,
+  Dropdown,
+  Pagination
+} from 'react-bootstrap'
+import Error from '../../../components/common/Error'
+import CustomBadge from '../../../components/common/customBadge'
+import withPrivateRoute from '../../../components/utils/withPrivateRoute'
+import PropTypes from 'prop-types'
+
+const ManageQuestionsPage = (props) => {
+  const [loading, setLoading] = useState(true)
+  const [questions, setQuestions] = useState([])
+  const [error, setError] = useState('')
+  const [constraints, setConstraints] = useState({
+    search: '',
+    difficulty: 3,
+    tags: []
+  })
+  const [sortBy, setSortBy] = useState({
+    id: false,
+    name: false
+  })
+  const [page, setPage] = useState(1)
+  const [pageCount, setPageCount] = useState(0)
+  const [perPageSize, setPerPageSize] = useState(10)
+  const [availableTags, setAvailableTags] = useState([])
+
+  const { isLoggedIn, user } = props
+  const { access_token: accessToken } = user
+
+  const { search, difficulty, tags } = constraints
+  const isConstraints = Boolean(search || (difficulty >= 0 && difficulty < 3) || tags.length)
+
+  useEffect(() => {
+    setLoading(true)
+
+    fetch(`${baseUrl}/tags`)
+      .then(async (res) => {
+        const { success, error, results } = await res.json()
+        if (success) {
+          setError('')
+          setAvailableTags(results)
+        } else {
+          setAvailableTags([])
+          setError(error.sqlMessage || error)
+        }
+        setLoading(false)
+      })
+      .catch((error) => {
+        setError(error.message)
+        setLoading(false)
+        setAvailableTags([])
+      })
+  }, [])
+
+  useEffect(() => {
+    setPage(1)
+  }, [constraints])
+
+  useEffect(() => {
+    if (!availableTags.length && questions.length) {
+      return
+    }
+
+    setLoading(true)
+
+    let url = `${baseUrl}/questions/editor_questions?`
+
+    if (search) { url += `search=${search}&` }
+
+    if (difficulty >= 0 && difficulty < 3) {
+      url += `difficulty=${difficulties[+difficulty].toLowerCase()}&`
+    }
+
+    if (tags.length) {
+      tags.forEach(tag => {
+        url += `tag_ids[]=${tag.id}&`
+      })
+    }
+
+    if (page) {
+      url += `page=${page}&`
+    }
+
+    if (perPageSize) {
+      url += `per_page_size=${perPageSize}&`
+    }
+
+    const sort = []
+
+    Object.entries(sortBy).forEach(([field, sortOrder]) => {
+      sortOrder && sort.push({ id: field, desc: sortOrder === 'DESC' })
+    })
+
+    if (sort.length) {
+      url += `sort=${JSON.stringify(sort)}`
+    }
+
+    const reqHeaders = new Headers()
+    reqHeaders.append('access_token', accessToken)
+    const requestOptions = {
+      method: 'GET',
+      headers: reqHeaders
+    }
+
+    fetch(url, requestOptions)
+      .then(async (res) => {
+        const { success, error, results } = await res.json()
+        if (success) {
+          setError('')
+          setQuestions(results.questions)
+          setPageCount(results.page_count)
+        } else {
+          setQuestions([])
+          setPageCount(0)
+          setError(error.sqlMessage || error)
+        }
+        setLoading(false)
+      })
+      .catch((error) => {
+        setError(error.message)
+        setLoading(false)
+        setQuestions([])
+        setPageCount(0)
+      })
+  }, [constraints, page, perPageSize, sortBy])
+
+  const handleSort = useCallback((field) => setSortBy(prev => {
+    const newVal = { ...prev }
+    newVal[field] = prev[field] ? prev[field] === 'ASC' ? 'DESC' : 'ASC' : 'ASC'
+    return newVal
+  }), [])
+
+  const difficultyTypeMap = {
+    easy: 'success',
+    medium: 'warning',
+    hard: 'danger'
+  }
+
+  const difficulties = ['Easy', 'Medium', 'Hard']
+
+  const badgeVariants = ['primary', 'success', 'danger', 'info', 'warning', 'light']
+
+  return (
+      <>
+        <AdminNavbar
+            user={user}
+            isLoggedIn={isLoggedIn}
+            activeNav="questions"
+        />
+        <div className="container mt-3">
+            <ListGroupItem>
+                <Row>
+                <Col md={3}>
+                    <Form inline>
+                        <InputGroup>
+                            <InputGroup.Prepend>
+                                <InputGroup.Text id="search-addon">
+                                    <span className="fa fa-search" />
+                                </InputGroup.Text>
+                            </InputGroup.Prepend>
+                            <FormControl
+                                style={{ height: '50%' }}
+                                type="text"
+                                placeholder="Search by Name"
+                                className="mr-sm-2"
+                                value={search}
+                                onChange={(e) => setConstraints(prev => ({ ...prev, search: e.target.value }))}
+                            />
+                        </InputGroup>
+                    </Form>
+                </Col>
+                <Col md={3} className="mt-1 text-center">
+                    <DropdownButton
+                        title="Difficulty"
+                        variant="warning"
+                        onSelect={(key) => setConstraints(prev => ({ ...prev, difficulty: +key }))}
+                    >
+                    <Dropdown.Item eventKey="0" active={difficulty === 0}>Easy</Dropdown.Item>
+                    <Dropdown.Item eventKey="1" active={difficulty === 1}>Medium</Dropdown.Item>
+                    <Dropdown.Item eventKey="2" active={difficulty === 2}>Hard</Dropdown.Item>
+                    <Dropdown.Item eventKey="3" active={difficulty === 3}>All</Dropdown.Item>
+                    </DropdownButton>
+                </Col>
+                <Col md={3} className="mt-1 text-center">
+                    <DropdownButton
+                        title="Tags"
+                        variant="info"
+                        onSelect={(key) => setConstraints(prev => ({
+                          ...prev,
+                          tags: [...prev.tags, availableTags[key]]
+                        }))}
+                    >
+                    {availableTags.map((tag, idx) => (
+                        <Dropdown.Item
+                            key={idx}
+                            eventKey={idx}
+                            disabled={tags.find(tag1 => tag1.id === tag.id)}
+                        >
+                            {tag.name}
+                        </Dropdown.Item>
+                    ))}
+                    </DropdownButton>
+                </Col>
+                <Col md={3} className="mt-1 text-center">
+                    <DropdownButton
+                        title="Rows per page"
+                        variant="success"
+                        onSelect={(key) => setPerPageSize(+key)}
+                    >
+                        <Dropdown.Item eventKey={5} active={perPageSize === 5}>5</Dropdown.Item>
+                        <Dropdown.Item eventKey={10} active={perPageSize === 10}>10</Dropdown.Item>
+                        <Dropdown.Item eventKey={15} active={perPageSize === 15}>15</Dropdown.Item>
+                        <Dropdown.Item eventKey={20} active={perPageSize === 20}>20</Dropdown.Item>
+                    </DropdownButton>
+                </Col>
+                </Row>
+            </ListGroupItem>
+            {isConstraints &&
+                <ListGroupItem>
+                <Row>
+                    {Object.entries(constraints).map(([type, constraint], idx) => {
+                      if (constraint !== '') {
+                        if (type !== 'tags') {
+                          let variant = 'success'
+                          if (type === 'difficulty') {
+                            if (difficulty >= 3 || difficulty < 0) {
+                              return null
+                            }
+                            constraint = difficulties[+constraint]
+                            variant = difficultyTypeMap[constraint.toLowerCase()]
+                          }
+                          return (
+                            <Col
+                                key={idx}
+                                xs={12}
+                            >
+                            <CustomBadge
+                                message={constraint}
+                                variant={variant}
+                                crossBtn
+                                onClose={() => setConstraints(prev => {
+                                  const newVal = { ...prev }
+                                  newVal[`${type}`] = type === 'difficulty' ? 3 : ''
+                                  return newVal
+                                })}
+                            />
+                            </Col>
+                          )
+                        } else {
+                          return (
+                            <>
+                            {constraint.map((tag, idx) => (
+                                <Col
+                                key={idx}
+                                xs={12}
+                                >
+                                <CustomBadge
+                                    message={tag.name}
+                                    variant={badgeVariants[Math.floor(Math.random() * badgeVariants.length)]}
+                                    crossBtn
+                                    onClose={() => setConstraints(prev => ({
+                                      ...prev,
+                                      tags: [...prev.tags.slice(0, idx), ...prev.tags.slice(idx + 1)]
+                                    }))}
+                                />
+                                </Col>
+                            ))}
+                            </>
+                          )
+                        }
+                      } else {
+                        return null
+                      }
+                    })}
+                </Row>
+                </ListGroupItem>
+            }
+            {loading && <Loading />}
+            {!loading && error && <Error message={error}></Error>}
+            {!loading && !error &&
+                <ManageQuestions
+                    questions={questions}
+                    sortBy={sortBy}
+                    handleSort={handleSort}
+                />
+            }
+            <br />
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Pagination>
+                    {new Array(pageCount).fill(0).map((_, idx) => (
+                        <Pagination.Item
+                            key={idx}
+                            active={page === idx + 1}
+                            onClick={() => setPage(idx + 1)}
+                        >
+                            {idx + 1}
+                        </Pagination.Item>
+                    ))}
+                </Pagination>
+            </div>
+        </div>
+    </>
+  )
+}
+
+ManageQuestionsPage.propTypes = {
+  isLoggedIn: PropTypes.bool,
+  user: PropTypes.shape({
+    username: PropTypes.string,
+    access_token: PropTypes.string,
+    isAdmin: PropTypes.number
+  })
+}
+
+export default withPrivateRoute(ManageQuestionsPage)

--- a/frontend/pages/practice/index.js
+++ b/frontend/pages/practice/index.js
@@ -1,0 +1,296 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import Loading from '../../components/common/Loading'
+import baseUrl from '../../shared/baseUrl'
+import Practice from '../../components/practice/index'
+import {
+  ListGroupItem, Row, Col, Form,
+  FormControl,
+  InputGroup,
+  DropdownButton,
+  Dropdown,
+  Pagination
+} from 'react-bootstrap'
+import Error from '../../components/common/Error'
+import CustomBadge from '../../components/common/customBadge'
+
+const PracticePage = () => {
+  const [loading, setLoading] = useState(true)
+  const [questions, setQuestions] = useState([])
+  const [error, setError] = useState('')
+  const [constraints, setConstraints] = useState({
+    search: '',
+    difficulty: 3,
+    tags: []
+  })
+  const [sortBy, setSortBy] = useState({
+    id: false,
+    name: false
+  })
+  const [page, setPage] = useState(1)
+  const [pageCount, setPageCount] = useState(0)
+  const [perPageSize, setPerPageSize] = useState(10)
+  const [availableTags, setAvailableTags] = useState([])
+
+  const { search, difficulty, tags } = constraints
+  const isConstraints = Boolean(search || (difficulty >= 0 && difficulty < 3) || tags.length)
+
+  useEffect(() => {
+    setLoading(true)
+
+    fetch(`${baseUrl}/tags`)
+      .then(async (res) => {
+        const { success, error, results } = await res.json()
+        if (success) {
+          setError('')
+          setAvailableTags(results)
+        } else {
+          setAvailableTags([])
+          setError(error.sqlMessage || error)
+        }
+        setLoading(false)
+      })
+      .catch((error) => {
+        setError(error.message)
+        setLoading(false)
+        setAvailableTags([])
+      })
+  }, [])
+
+  useEffect(() => {
+    setPage(1)
+  }, [constraints])
+
+  useEffect(() => {
+    if (!availableTags.length && questions.length) {
+      return
+    }
+
+    setLoading(true)
+
+    let url = `${baseUrl}/questions?`
+
+    if (search) { url += `search=${search}&` }
+
+    if (difficulty >= 0 && difficulty < 3) {
+      url += `difficulty=${difficulties[+difficulty].toLowerCase()}&`
+    }
+
+    if (tags.length) {
+      tags.forEach(tag => {
+        url += `tag_ids[]=${tag.id}&`
+      })
+    }
+
+    if (page) {
+      url += `page=${page}&`
+    }
+
+    if (perPageSize) {
+      url += `per_page_size=${perPageSize}&`
+    }
+
+    const sort = []
+
+    Object.entries(sortBy).forEach(([field, sortOrder]) => {
+      sortOrder && sort.push({ id: field, desc: sortOrder === 'DESC' })
+    })
+
+    if (sort.length) {
+      url += `sort=${JSON.stringify(sort)}`
+    }
+
+    fetch(url)
+      .then(async (res) => {
+        const { success, error, results } = await res.json()
+        if (success) {
+          setError('')
+          setQuestions(results.questions)
+          setPageCount(results.page_count)
+        } else {
+          setQuestions([])
+          setPageCount(0)
+          setError(error.sqlMessage || error)
+        }
+        setLoading(false)
+      })
+      .catch((error) => {
+        setError(error.message)
+        setLoading(false)
+        setQuestions([])
+        setPageCount(0)
+      })
+  }, [constraints, page, perPageSize, sortBy])
+
+  const handleSort = useCallback((field) => setSortBy(prev => {
+    const newVal = { ...prev }
+    newVal[field] = prev[field] ? prev[field] === 'ASC' ? 'DESC' : 'ASC' : 'ASC'
+    return newVal
+  }), [])
+
+  const difficultyTypeMap = {
+    easy: 'success',
+    medium: 'warning',
+    hard: 'danger'
+  }
+
+  const difficulties = ['Easy', 'Medium', 'Hard']
+
+  const badgeVariants = ['primary', 'success', 'danger', 'info', 'warning', 'light']
+
+  return (
+    <div className="container mt-3">
+      <ListGroupItem>
+        <Row>
+          <Col md={3}>
+            <Form inline>
+              <InputGroup>
+                <InputGroup.Prepend>
+                  <InputGroup.Text id="search-addon">
+                    <span className="fa fa-search" />
+                  </InputGroup.Text>
+                </InputGroup.Prepend>
+                <FormControl
+                  style={{ height: '50%' }}
+                  type="text"
+                  placeholder="Search by Name"
+                  className="mr-sm-2"
+                  value={search}
+                  onChange={(e) => setConstraints(prev => ({ ...prev, search: e.target.value }))}
+                />
+              </InputGroup>
+            </Form>
+          </Col>
+          <Col md={3} className="mt-1 text-center">
+            <DropdownButton
+              title="Difficulty"
+              variant="warning"
+              onSelect={(key) => setConstraints(prev => ({ ...prev, difficulty: +key }))}
+            >
+              <Dropdown.Item eventKey="0" active={difficulty === 0}>Easy</Dropdown.Item>
+              <Dropdown.Item eventKey="1" active={difficulty === 1}>Medium</Dropdown.Item>
+              <Dropdown.Item eventKey="2" active={difficulty === 2}>Hard</Dropdown.Item>
+              <Dropdown.Item eventKey="3" active={difficulty === 3}>All</Dropdown.Item>
+            </DropdownButton>
+          </Col>
+          <Col md={3} className="mt-1 text-center">
+            <DropdownButton
+              title="Tags"
+              variant="info"
+              onSelect={(key) => setConstraints(prev => ({
+                ...prev,
+                tags: [...prev.tags, availableTags[key]]
+              }))}
+            >
+              {availableTags.map((tag, idx) => (
+                <Dropdown.Item
+                  key={idx}
+                  eventKey={idx}
+                  disabled={tags.find(tag1 => tag1.id === tag.id)}
+                >
+                  {tag.name}
+                </Dropdown.Item>
+              ))}
+            </DropdownButton>
+          </Col>
+          <Col md={3} className="mt-1 text-center">
+            <DropdownButton
+              title="Rows per page"
+              variant="success"
+              onSelect={(key) => setPerPageSize(+key)}
+            >
+              <Dropdown.Item eventKey={5} active={perPageSize === 5}>5</Dropdown.Item>
+              <Dropdown.Item eventKey={10} active={perPageSize === 10}>10</Dropdown.Item>
+              <Dropdown.Item eventKey={15} active={perPageSize === 15}>15</Dropdown.Item>
+              <Dropdown.Item eventKey={20} active={perPageSize === 20}>20</Dropdown.Item>
+            </DropdownButton>
+          </Col>
+        </Row>
+      </ListGroupItem>
+      {isConstraints &&
+        <ListGroupItem>
+          <Row>
+            {Object.entries(constraints).map(([type, constraint], idx) => {
+              if (constraint !== '') {
+                if (type !== 'tags') {
+                  let variant = 'success'
+                  if (type === 'difficulty') {
+                    if (difficulty >= 3 || difficulty < 0) {
+                      return null
+                    }
+                    constraint = difficulties[+constraint]
+                    variant = difficultyTypeMap[constraint.toLowerCase()]
+                  }
+                  return (
+                    <Col
+                      key={idx}
+                      xs={12}
+                    >
+                      <CustomBadge
+                        message={constraint}
+                        variant={variant}
+                        crossBtn
+                        onClose={() => setConstraints(prev => {
+                          const newVal = { ...prev }
+                          newVal[`${type}`] = type === 'difficulty' ? 3 : ''
+                          return newVal
+                        })}
+                      />
+                    </Col>
+                  )
+                } else {
+                  return (
+                    <>
+                      {constraint.map((tag, idx) => (
+                        <Col
+                          key={idx}
+                          xs={12}
+                        >
+                          <CustomBadge
+                            message={tag.name}
+                            variant={badgeVariants[Math.floor(Math.random() * badgeVariants.length)]}
+                            crossBtn
+                            onClose={() => setConstraints(prev => ({
+                              ...prev,
+                              tags: [...prev.tags.slice(0, idx), ...prev.tags.slice(idx + 1)]
+                            }))}
+                          />
+                        </Col>
+                      ))}
+                    </>
+                  )
+                }
+              } else {
+                return null
+              }
+            })}
+          </Row>
+        </ListGroupItem>
+      }
+      {loading && <Loading />}
+      {!loading && error && <Error message={error}></Error>}
+      {!loading && !error &&
+        <Practice
+          questions={questions}
+          sortBy={sortBy}
+          handleSort={handleSort}
+        />
+      }
+      <br />
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Pagination>
+          {new Array(pageCount).fill(0).map((_, idx) => (
+            <Pagination.Item
+              key={idx}
+              active={page === idx + 1}
+              onClick={() => setPage(idx + 1)}
+            >
+              {idx + 1}
+            </Pagination.Item>
+          ))}
+        </Pagination>
+      </div>
+    </div>
+  )
+}
+
+export default PracticePage

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -13,3 +13,7 @@ body {
 .dropdown-item:active {
   background-color: inherit;
 }
+
+.hover-cursor-pointer:hover {
+  cursor: pointer;
+}

--- a/server/models/contests/createContest.js
+++ b/server/models/contests/createContest.js
@@ -17,13 +17,13 @@ function createContest({ username, body }) {
       public,
       start_time,
       end_time,
+      confidential_questions: confidentialQuestions,
     } = body
     const startTime = new Date(start_time)
     const endTime = new Date(end_time)
     let about = body.about || null
     let rules = body.rules || null
     let prizes = body.prizes || null
-    let confidentialQuestions = body.confidential_questions || null
     let currentId
     pool.getConnection((error, connection) => {
       if (error) {

--- a/server/models/questions/getEditorQuestions.js
+++ b/server/models/questions/getEditorQuestions.js
@@ -2,42 +2,132 @@ const { pool } = require('../database')
 
 /**
  *
+ * @param {Array} sortParams
+ * @return {String}
+ */
+function sortQuery(sortParams) {
+  if (!Array.isArray(sortParams)) {
+    return ''
+  }
+  return (
+    ' ORDER BY ' +
+    sortParams
+      .map(({ id, desc }) => `${id} ${desc ? 'DESC' : 'ASC'}`)
+      .join(', ')
+  )
+}
+
+/**
+ *
  * @param {*} param0
  * @param {String} param0.username
- * @param {Number} param0.cursor
  * @param {Number} param0.search
- * @param {Number} param0.limit
+ * @param {Number} param0.tag_ids
+ * @param {String} param0.difficulty
+ * @param {Number} param0.per_page_size
+ * @param {Number} param0.page
+ * @param {Array} param0.sort
  * @return {Promise}
  */
-function getEditorQuestions({ username, cursor, limit, search }) {
+function getEditorQuestions({
+  username,
+  search,
+  tag_ids: tagIds,
+  difficulty,
+  per_page_size: perPageSize,
+  page,
+  sort,
+}) {
   return new Promise((resolve, reject) => {
-    let query = `SELECT * FROM questions q
-                INNER JOIN questions_editors qe ON q.id=qe.question_id WHERE `
+    let countQuery = `SELECT COUNT(DISTINCT q.id) AS total FROM questions q
+                      INNER JOIN questions_editors qe ON q.id=qe.question_id `
+    const cQArr = []
+
+    let query = `SELECT DISTINCT q.id, q.name, q.difficulty, q.creator FROM questions q
+                INNER JOIN questions_editors qe ON q.id=qe.question_id `
     const qArr = []
 
-    if (cursor) {
-      query += `q.id>? AND `
-      qArr.push(+cursor)
+    if (
+      tagIds &&
+      Array.isArray(tagIds) &&
+      !tagIds.some(isNaN) &&
+      tagIds.length
+    ) {
+      countQuery += `INNER JOIN questions_tags qt ON q.id=qt.question_id WHERE qt.tag_id IN(`
+      query += `INNER JOIN questions_tags qt ON q.id=qt.question_id WHERE qt.tag_id IN(`
+
+      tagIds.forEach((tagId, idx) => {
+        query += `?`
+        countQuery += `?`
+        if (idx != tagIds.length - 1) {
+          query += `,`
+          countQuery += `,`
+        } else {
+          query += `)`
+          countQuery += `)`
+        }
+        qArr.push(+tagId)
+        cQArr.push(+tagId)
+      })
+      query += ` AND `
+      countQuery += ` AND `
+    } else {
+      query += `WHERE `
+      countQuery += `WHERE `
     }
 
-    query += `qe.editor=? `
+    query += ` qe.editor=? `
+    countQuery += ` qe.editor=? `
     qArr.push(username)
+    cQArr.push(username)
+
+    if (
+      difficulty &&
+      (difficulty === 'easy' ||
+        difficulty === 'medium' ||
+        difficulty === 'hard')
+    ) {
+      query += ` AND difficulty=? `
+      countQuery += ` AND difficulty=? `
+      qArr.push(difficulty)
+      cQArr.push(difficulty)
+    }
 
     if (search) {
       query += `AND q.name LIKE ? `
+      countQuery += `AND q.name LIKE ? `
       qArr.push(`%${search}%`)
+      cQArr.push(`%${search}%`)
     }
 
-    if (limit) {
-      query += `LIMIT ?`
-      qArr.push(+limit)
+    if (sort) {
+      query += sortQuery(JSON.parse(sort))
     }
 
-    pool.query(query, qArr, (error, results) => {
+    pool.query(countQuery, cQArr, (error, results) => {
       if (error || !results) {
         return reject(error)
       }
-      return resolve({ questions_data: results })
+
+      const totalRows = results[0].total
+      if (!totalRows) {
+        return resolve({ questions: [], page_count: 0 })
+      }
+
+      perPageSize = parseInt(perPageSize, 10) || 10
+      const numPages = Math.ceil(totalRows / perPageSize)
+      const pageIndex = parseInt(page, 10) - 1 || 0
+      const offset = perPageSize * pageIndex
+
+      query += ` LIMIT ?,?`
+      qArr.push(offset, perPageSize)
+
+      pool.query(query, qArr, (error, results) => {
+        if (error || !results) {
+          return reject(error)
+        }
+        return resolve({ questions: results, page_count: numPages })
+      })
     })
   })
 }

--- a/server/models/questions/getPublicContestQuestions.js
+++ b/server/models/questions/getPublicContestQuestions.js
@@ -1,59 +1,133 @@
 const { pool } = require('../database')
 
 /**
+ *
+ * @param {Array} sortParams
+ * @return {String}
+ */
+function sortQuery(sortParams) {
+  if (!Array.isArray(sortParams)) {
+    return ''
+  }
+  return (
+    ' ORDER BY ' +
+    sortParams
+      .map(({ id, desc }) => `${id} ${desc ? 'DESC' : 'ASC'}`)
+      .join(', ')
+  )
+}
+
+/**
  * @param {*} param0
  * @param {Number} param0.cursor
  * @param {String} param0.search
  * @param {Number} param0.limit
  * @param {Number} param0.tag_ids
+ * @param {String} param0.difficulty
+ * @param {Number} param0.per_page_size
+ * @param {Number} param0.page
+ * @param {Array} param0.sort
  * @return {Promise}
  */
 
-function getPublicContestQuestions({ cursor, limit, search, tag_ids: tagIds }) {
+function getPublicContestQuestions({
+  search,
+  tag_ids: tagIds,
+  difficulty,
+  per_page_size: perPageSize,
+  page,
+  sort,
+}) {
   return new Promise((resolve, reject) => {
-    let query = `SELECT * FROM contests c
+    let countQuery = `SELECT COUNT(DISTINCT q.id) AS total FROM contests c
+                      INNER JOIN contests_questions cq ON c.id=cq.contest_id
+                      INNER JOIN questions q ON cq.question_id=q.id `
+    const cQArr = []
+
+    let query = `SELECT DISTINCT q.id, q.name, q.difficulty FROM contests c
                 INNER JOIN contests_questions cq ON c.id=cq.contest_id
                 INNER JOIN questions q ON cq.question_id=q.id `
     const qArr = []
 
-    if (tagIds && tagIds.length) {
+    if (
+      tagIds &&
+      Array.isArray(tagIds) &&
+      !tagIds.some(isNaN) &&
+      tagIds.length
+    ) {
+      countQuery += `INNER JOIN questions_tags qt ON q.id=qt.question_id WHERE qt.tag_id IN(`
       query += `INNER JOIN questions_tags qt ON q.id=qt.question_id WHERE qt.tag_id IN(`
+
       tagIds.forEach((tagId, idx) => {
         query += `?`
+        countQuery += `?`
         if (idx != tagIds.length - 1) {
           query += `,`
+          countQuery += `,`
         } else {
           query += `)`
+          countQuery += `)`
         }
         qArr.push(+tagId)
+        cQArr.push(+tagId)
       })
       query += ` AND `
+      countQuery += ` AND `
     } else {
       query += `WHERE `
+      countQuery += `WHERE `
     }
 
-    if (cursor) {
-      query += `q.id>? AND `
-      qArr.push(+cursor)
+    if (
+      difficulty &&
+      (difficulty === 'easy' ||
+        difficulty === 'medium' ||
+        difficulty === 'hard')
+    ) {
+      query += `difficulty=? AND `
+      countQuery += `difficulty=? AND `
+      qArr.push(difficulty)
+      cQArr.push(difficulty)
     }
 
-    query += `c.end_time <= NOW() `
+    query += `c.end_time <= NOW() AND c.public  = 1 AND c.confidential_questions = 0 `
+    countQuery += `c.end_time <= NOW() AND c.public  = 1 AND c.confidential_questions = 0 `
 
     if (search) {
       query += `AND q.name LIKE ? `
+      countQuery += `AND q.name LIKE ? `
       qArr.push(`%${search}%`)
+      cQArr.push(`%${search}%`)
     }
 
-    if (limit) {
-      query += `LIMIT ?`
-      qArr.push(+limit)
+    if (sort) {
+      query += sortQuery(JSON.parse(sort))
     }
 
-    pool.query(query, qArr, (error, results) => {
+    pool.query(countQuery, cQArr, (error, results) => {
       if (error || !results) {
         return reject(error)
       }
-      return resolve({ questions_data: results })
+
+      const totalRows = results[0].total
+      if (!totalRows) {
+        return resolve({ questions: [], page_count: 0 })
+      }
+
+      perPageSize = parseInt(perPageSize, 10) || 10
+      const numPages = Math.ceil(totalRows / perPageSize)
+      const pageIndex = parseInt(page, 10) - 1 || 0
+      const offset = perPageSize * pageIndex
+
+      query += ` LIMIT ?,?`
+      qArr.push(offset, perPageSize)
+
+      pool.query(query, qArr, (error, results) => {
+        if (error || !results) {
+          return reject(error)
+        }
+        return resolve({ questions: results, page_count: numPages })
+      })
     })
   })
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3317,7 +3317,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3860,6 +3861,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -5298,6 +5300,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -5311,6 +5314,7 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -6545,7 +6549,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",
@@ -7420,7 +7425,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -89,8 +89,8 @@ router.use('/questions', questionsRouter.createQuestion)
 router.use('/questions', questionsRouter.getQuestion)
 router.use('/questions', questionsRouter.getPublicContestQuestions)
 
-router.use('/tag', tagsRouter.createTagRouter)
-router.use('/tag', tagsRouter.getTagRouter)
+router.use('/tags', tagsRouter.createTagRouter)
+router.use('/tags', tagsRouter.getTagRouter)
 
 app.use(router)
 

--- a/server/routes/tags/getTag.js
+++ b/server/routes/tags/getTag.js
@@ -1,9 +1,8 @@
 const express = require('express')
 const router = express.Router()
-const middleware = require('../middlewares')
 const tags = require('../../models/tags')
 
-router.get('/', middleware.verifyUserAccessToken, async (request, response) => {
+router.get('/', async (request, response) => {
   tags
     .getTag(request)
     .then((results) => {


### PR DESCRIPTION
### Frontend

1. Create practice page to display all public questions.

![practicePage](https://user-images.githubusercontent.com/45630095/103270204-6a99da80-49dd-11eb-87b1-d74a5f8dabc0.gif)

### Backend

1. Update `POST /questions` endpoint to support offset pagination with page_count being returned on every request.
2. Fix a small bug on `POST /questions` related to `confidential_questions`
2. Change `GET /tag` endpoint to `GET /tags`.
3. Update `GET /tags` endpoint to serve unauthorized users.